### PR TITLE
Dev revert closure optimisations ( local only )

### DIFF
--- a/src/core/BufferGeometry.js
+++ b/src/core/BufferGeometry.js
@@ -173,9 +173,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		// rotate geometry around world x-axis
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function rotateX( angle ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeRotationX( angle );
 
@@ -191,9 +193,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		// rotate geometry around world y-axis
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function rotateY( angle ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeRotationY( angle );
 
@@ -209,9 +213,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		// rotate geometry around world z-axis
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function rotateZ( angle ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeRotationZ( angle );
 
@@ -227,9 +233,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		// translate geometry
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function translate( x, y, z ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeTranslation( x, y, z );
 
@@ -245,9 +253,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 		// scale geometry
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function scale( x, y, z ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeScale( x, y, z );
 
@@ -261,9 +271,11 @@ Object.assign( BufferGeometry.prototype, EventDispatcher.prototype, {
 
 	lookAt: function () {
 
-		var obj = new Object3D();
+		var obj;
 
 		return function lookAt( vector ) {
+
+			if ( obj === undefined ) obj = new Object3D();
 
 			obj.lookAt( vector );
 

--- a/src/core/Geometry.js
+++ b/src/core/Geometry.js
@@ -110,9 +110,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 		// rotate geometry around world x-axis
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function rotateX( angle ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeRotationX( angle );
 
@@ -128,9 +130,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 		// rotate geometry around world y-axis
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function rotateY( angle ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeRotationY( angle );
 
@@ -146,9 +150,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 		// rotate geometry around world z-axis
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function rotateZ( angle ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeRotationZ( angle );
 
@@ -164,9 +170,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 		// translate geometry
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function translate( x, y, z ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeTranslation( x, y, z );
 
@@ -182,9 +190,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 		// scale geometry
 
-		var m1 = new Matrix4();
+		var m1;
 
 		return function scale( x, y, z ) {
+
+			if ( m1 === undefined ) m1 = new Matrix4();
 
 			m1.makeScale( x, y, z );
 
@@ -198,9 +208,11 @@ Object.assign( Geometry.prototype, EventDispatcher.prototype, {
 
 	lookAt: function () {
 
-		var obj = new Object3D();
+		var obj;
 
 		return function lookAt( vector ) {
+
+			if ( obj === undefined ) obj = new Object3D();
 
 			obj.lookAt( vector );
 

--- a/src/loaders/Loader.js
+++ b/src/loaders/Loader.js
@@ -106,11 +106,13 @@ Object.assign( Loader.prototype, {
 			CustomBlending: CustomBlending
 		};
 
-		var color = new Color();
-		var textureLoader = new TextureLoader();
-		var materialLoader = new MaterialLoader();
+		var color, textureLoader, materialLoader;
 
 		return function createMaterial( m, texturePath, crossOrigin ) {
+
+			if ( color === undefined ) color = new Color();
+			if ( textureLoader === undefined ) textureLoader = new TextureLoader();
+			if ( materialLoader === undefined ) materialLoader = new MaterialLoader();
 
 			// convert from old material format
 

--- a/src/math/Box3.js
+++ b/src/math/Box3.js
@@ -308,9 +308,11 @@ Object.assign( Box3.prototype, {
 
 	intersectsSphere: ( function () {
 
-		var closestPoint = new Vector3();
+		var closestPoint;
 
 		return function intersectsSphere( sphere ) {
+
+			if ( closestPoint === undefined ) closestPoint = new Vector3();
 
 			// Find the point on the AABB closest to the sphere center.
 			this.clampPoint( sphere.center, closestPoint );

--- a/src/math/Euler.js
+++ b/src/math/Euler.js
@@ -255,9 +255,11 @@ Object.assign( Euler.prototype, {
 
 	setFromQuaternion: function () {
 
-		var matrix = new Matrix4();
+		var matrix;
 
 		return function setFromQuaternion( q, order, update ) {
+
+			if ( matrix === undefined ) matrix = new Matrix4();
 
 			matrix.makeRotationFromQuaternion( q );
 

--- a/src/math/Matrix3.js
+++ b/src/math/Matrix3.js
@@ -92,9 +92,11 @@ Object.assign( Matrix3.prototype, {
 
 	applyToBufferAttribute: function () {
 
-		var v1 = new Vector3();
+		var v1;
 
 		return function applyToBufferAttribute( attribute ) {
+
+			if ( v1 === undefined ) v1 = new Vector3();
 
 			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 

--- a/src/math/Matrix4.js
+++ b/src/math/Matrix4.js
@@ -121,9 +121,11 @@ Object.assign( Matrix4.prototype, {
 
 	extractRotation: function () {
 
-		var v1 = new Vector3();
+		var v1;
 
 		return function extractRotation( m ) {
+
+			if ( v1 === undefined ) v1 = new Vector3();
 
 			var te = this.elements;
 			var me = m.elements;
@@ -317,11 +319,17 @@ Object.assign( Matrix4.prototype, {
 
 	lookAt: function () {
 
-		var x = new Vector3();
-		var y = new Vector3();
-		var z = new Vector3();
+		var x, y, z;
 
 		return function lookAt( eye, target, up ) {
+
+			if ( x === undefined ) {
+
+				x = new Vector3();
+				y = new Vector3();
+				z = new Vector3();
+
+			}
 
 			var te = this.elements;
 
@@ -434,9 +442,11 @@ Object.assign( Matrix4.prototype, {
 
 	applyToBufferAttribute: function () {
 
-		var v1 = new Vector3();
+		var v1;
 
 		return function applyToBufferAttribute( attribute ) {
+
+			if ( v1 === undefined ) v1 = new Vector3();
 
 			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
 
@@ -754,10 +764,16 @@ Object.assign( Matrix4.prototype, {
 
 	decompose: function () {
 
-		var vector = new Vector3();
-		var matrix = new Matrix4();
+		var vector, matrix;
 
 		return function decompose( position, quaternion, scale ) {
+
+			if ( vector === undefined ) {
+
+				vector = new Vector3();
+				matrix = new Matrix4();
+
+			}
 
 			var te = this.elements;
 

--- a/src/math/Quaternion.js
+++ b/src/math/Quaternion.js
@@ -351,8 +351,7 @@ Object.assign( Quaternion.prototype, {
 
 		// assumes direction vectors vFrom and vTo are normalized
 
-		var v1 = new Vector3();
-		var r;
+		var v1, r;
 
 		var EPS = 0.000001;
 

--- a/src/math/Sphere.js
+++ b/src/math/Sphere.js
@@ -26,9 +26,11 @@ Object.assign( Sphere.prototype, {
 
 	setFromPoints: function () {
 
-		var box = new Box3();
+		var box;
 
 		return function setFromPoints( points, optionalCenter ) {
+
+			if ( box === undefined ) box = new Box3(); // see #10547
 
 			var center = this.center;
 

--- a/src/math/Triangle.js
+++ b/src/math/Triangle.js
@@ -191,12 +191,18 @@ Object.assign( Triangle.prototype, {
 
 	closestPointToPoint: function () {
 
-		var plane = new Plane();
-		var edgeList = [ new Line3(), new Line3(), new Line3() ];
-		var projectedPoint = new Vector3();
-		var closestPoint = new Vector3();
+		var plane, edgeList, projectedPoint, closestPoint;
 
 		return function closestPointToPoint( point, optionalTarget ) {
+
+			if ( plane === undefined ) {
+
+				plane = new Plane();
+				edgeList = [ new Line3(), new Line3(), new Line3() ];
+				projectedPoint = new Vector3();
+				closestPoint = new Vector3();
+
+			}
 
 			var result = optionalTarget || new Vector3();
 			var minDistance = Infinity;

--- a/src/math/Vector2.js
+++ b/src/math/Vector2.js
@@ -268,10 +268,16 @@ Object.assign( Vector2.prototype, {
 
 	clampScalar: function () {
 
-		var min = new Vector2();
-		var max = new Vector2();
+		var min, max;
 
 		return function clampScalar( minVal, maxVal ) {
+
+			if ( min === undefined ) {
+
+				min = new Vector2();
+				max = new Vector2();
+
+			}
 
 			min.set( minVal, minVal );
 			max.set( maxVal, maxVal );

--- a/src/math/Vector3.js
+++ b/src/math/Vector3.js
@@ -234,7 +234,7 @@ Object.assign( Vector3.prototype, {
 
 	applyEuler: function () {
 
-		var quaternion = new Quaternion();
+		var quaternion;
 
 		return function applyEuler( euler ) {
 
@@ -244,6 +244,8 @@ Object.assign( Vector3.prototype, {
 
 			}
 
+			if ( quaternion === undefined ) quaternion = new Quaternion();
+
 			return this.applyQuaternion( quaternion.setFromEuler( euler ) );
 
 		};
@@ -252,9 +254,11 @@ Object.assign( Vector3.prototype, {
 
 	applyAxisAngle: function () {
 
-		var quaternion = new Quaternion();
+		var quaternion;
 
 		return function applyAxisAngle( axis, angle ) {
+
+			if ( quaternion === undefined ) quaternion = new Quaternion();
 
 			return this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
 
@@ -313,9 +317,11 @@ Object.assign( Vector3.prototype, {
 
 	project: function () {
 
-		var matrix = new Matrix4();
+		var matrix;
 
 		return function project( camera ) {
+
+			if ( matrix === undefined ) matrix = new Matrix4();
 
 			matrix.multiplyMatrices( camera.projectionMatrix, matrix.getInverse( camera.matrixWorld ) );
 			return this.applyMatrix4( matrix );
@@ -326,9 +332,11 @@ Object.assign( Vector3.prototype, {
 
 	unproject: function () {
 
-		var matrix = new Matrix4();
+		var matrix;
 
 		return function unproject( camera ) {
+
+			if ( matrix === undefined ) matrix = new Matrix4();
 
 			matrix.multiplyMatrices( camera.matrixWorld, matrix.getInverse( camera.projectionMatrix ) );
 			return this.applyMatrix4( matrix );
@@ -403,10 +411,16 @@ Object.assign( Vector3.prototype, {
 
 	clampScalar: function () {
 
-		var min = new Vector3();
-		var max = new Vector3();
+		var min, max;
 
 		return function clampScalar( minVal, maxVal ) {
+
+			if ( min === undefined ) {
+
+				min = new Vector3();
+				max = new Vector3();
+
+			}
 
 			min.set( minVal, minVal, minVal );
 			max.set( maxVal, maxVal, maxVal );
@@ -571,9 +585,11 @@ Object.assign( Vector3.prototype, {
 
 	projectOnPlane: function () {
 
-		var v1 = new Vector3();
+		var v1;
 
 		return function projectOnPlane( planeNormal ) {
+
+			if ( v1 === undefined ) v1 = new Vector3();
 
 			v1.copy( this ).projectOnVector( planeNormal );
 
@@ -588,9 +604,11 @@ Object.assign( Vector3.prototype, {
 		// reflect incident vector off plane orthogonal to normal
 		// normal is assumed to have unit length
 
-		var v1 = new Vector3();
+		var v1;
 
 		return function reflect( normal ) {
+
+			if ( v1 === undefined ) v1 = new Vector3();
 
 			return this.sub( v1.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
 


### PR DESCRIPTION
Recent additions for r85 concerning closure performance optimisations cause issues with webpack/babel module transpiling ( circular references ).

This reverts those specific changes